### PR TITLE
Fix a deadlock caused by a timeout.

### DIFF
--- a/go/consumer.go
+++ b/go/consumer.go
@@ -29,8 +29,8 @@ func main() {
 
 	for {
 		endChan := make(chan int)
-		respChan := make(chan mq_http_sdk.ConsumeMessageResponse)
-		errChan := make(chan error)
+		respChan := make(chan mq_http_sdk.ConsumeMessageResponse,1)
+		errChan := make(chan error,1)
 		go func() {
 			select {
 			case resp := <-respChan:


### PR DESCRIPTION
respChan := make(chan mq_http_sdk.ConsumeMessageResponse)
errChan := make(chan error)
case <-time.After(35 * time.Second)

chan的长度是0，当35秒超时触发， 会导致consumer.ConsumeMessage无法写入chan。