### PR TITLE
FIX: fix main blocked

### DIFF
--- a/go/consumer.go
+++ b/go/consumer.go
@@ -84,7 +84,7 @@ func main() {
 
 		// 长轮询消费消息
 		// 长轮询表示如果topic没有消息则请求会在服务端挂住3s，3s内如果有消息可以消费则立即返回
-		mqConsumer.ConsumeMessage(respChan, errChan,
+		go mqConsumer.ConsumeMessage(respChan, errChan,
 			3, // 一次最多消费3条(最多可设置为16条)
 			3, // 长轮询时间3秒（最多可设置为30秒）
 		)


### PR DESCRIPTION
https://github.com/aliyunmq/mq-http-samples/blob/9d47cd58a2882be4eb6549d3071ac85335283b99/go/consumer.go#L77-L91

这一段代码有问题，上面35秒超时之后(也就是35秒没有收到mqConsumer.ConsumeMessage传出来的errChan和respChan)，会向endChan里给信号，但是下面的mqConsumer.ConsumeMessage是同步逻辑，所以存在mqConsumer.ConsumeMessage卡死的可能，虽然上面的goroutine里向endChan给了信号，但是不会进入下一个loop


这个坑我已经踩了，可以修复一下。不然一超时就凉了。